### PR TITLE
Update 10.11-implement-where-function.dart

### DIFF
--- a/solutions/10.11-implement-where-function.dart
+++ b/solutions/10.11-implement-where-function.dart
@@ -1,6 +1,6 @@
 void main() {
   const list = [1, 2, 3, 4];
-  final odd = where(list, (value) => value % 2 == 1);
+  final odd = where(list, (int value) => value % 2 == 1);
   print(odd);
 }
 


### PR DESCRIPTION
In the previous code, we've got this error message :  "The operator '%' can't be unconditionally invoked because the receiver can be 'null'. Try adding a null check to the target ('!').dart(unchecked_use_of_nullable_value)". I found a simple a solution : typing "value" with int.